### PR TITLE
fix: use common header to avoid receiving a 403 http error

### DIFF
--- a/sportsbetting/bookmakers/winamax.py
+++ b/sportsbetting/bookmakers/winamax.py
@@ -28,7 +28,7 @@ def parse_winamax(url):
         tournament_id = -1
     sport_id = int(ids.split("/")[0])
     try:
-        req = urllib.request.Request(url)
+        req = urllib.request.Request(url, headers = { 'User-Agent': 'Mozilla/5.0' })
         webpage = urllib.request.urlopen(req, timeout=10).read()
         soup = BeautifulSoup(webpage, features="lxml")
     except urllib.error.HTTPError:


### PR DESCRIPTION
Allow to retrieve data from winamax and not to be blocked by a 403 http error anymore